### PR TITLE
Key accumulation bug

### DIFF
--- a/lib/HotKeys.js
+++ b/lib/HotKeys.js
@@ -46,7 +46,7 @@ const getSequencesFromMap = (hotKeyName, hotKeyMap = {},) => {
   return [sequences];
 };
 
-const bindKeys = (bindArray, kbjs, wrapper, handlers, keyMap) => {
+const buildBindArray = (bindArray, kbjs, wrapper, handlers, keyMap) => {
   Object.keys(handlers).forEach(h => {
     let sequences = getSequencesFromMap(h, keyMap);
 
@@ -68,7 +68,6 @@ const bindKeys = (bindArray, kbjs, wrapper, handlers, keyMap) => {
         kbjs.on(keyCombo, wrapped.fn);
         bindArray.push(wrapped);
       }
-
     });
   });
 };
@@ -164,6 +163,7 @@ class HotKeys extends React.Component {
         this.props.HKcontext.hotKeyParent.childHandledSequence(sequence);
       }
 
+      console.log(this.props.id);
       handler(e);
     }
   };
@@ -186,22 +186,27 @@ class HotKeys extends React.Component {
     this.keyboardjs.stop();
     this.localKeybindings = [];
     // bind local keys first, preferring their keyMapped sequences over potential duplicates from context.
-    bindKeys(
+    buildBindArray(
       this.localKeybindings,
       this.keyboardjs,
       this.handlerWrapper,
       handlers,
       keyMap
     );
-    bindKeys(
+    // add keys from context into binding array...
+    buildBindArray(
       this.localKeybindings,
       this.keyboardjs,
       this.handlerWrapper,
       handlers,
       combinedKeyMap
     );
-    // don't even watch for keyPresses in element if localKeyBindings have a lenght of 0...
     if (this.localKeybindings.length !== 0) {
+      // finally bind keys...
+      this.localKeybindings.forEach((k) => {
+        this.keyboardjs.on(k.keyCombo, k.fn);
+      });
+      // and watch... (we don't even watch if no key bindings were stored)
       this.keyboardjs.watch(this.attachment);
     }
     
@@ -238,6 +243,9 @@ class HotKeys extends React.Component {
     if (onBlur) {
       onBlur(...args);
     }
+
+    // clear keyboardJS' array of previously pressed keys..
+    kbjs.releaseAllKeys();
     if (hotKeyParent) {
       hotKeyParent.childHandledSequence(null);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-react-hotkeys",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Stripes' hotkey library based on react-hotkeys.",
   "main": "index",
   "module": "index.es",


### PR DESCRIPTION
keyboardjs retains pressed keys in an array for each instance... when the key is released, this is supposed to be unwound, but for some reason it isn't... additionally, when the element is blurred (as in focus/blur) the array of pressed keys should be cleared (but they are not).
This manually calls `keyboardjs.releaseAllKeys` on blur of the `HotKeys` element so that future focusings can start with a clean slate.