### PR TITLE
Bugfix-multiple handler calls

### DIFF
--- a/lib/HotKeys.js
+++ b/lib/HotKeys.js
@@ -11,18 +11,18 @@ import { withHotKeys, HotKeysProvider } from "./HotKeysContext";
 import Keyboard from "keyboardjs/lib/keyboard";
 import usLocale from "keyboardjs/locales/us";
 
-const buildMap = (contextMap = {}, newMap = {}, thisMap = {}) =>
-  Object.assign({}, contextMap, newMap, thisMap);
+const buildMap = (currentMap = {}, contextMap = {}, propsMap = {}) =>
+  Object.assign({}, currentMap, contextMap, propsMap);
 
 const updateMap = (
   contextMap = {},
-  newMap = {},
-  thisMap = {},
-  currentMap = {}
+  propsMap = {},
+  currentMap = {},
+  previousMap = {},
 ) => {
-  const nextMap = buildMap(contextMap, newMap, thisMap);
+  const nextMap = buildMap(currentMap, contextMap, propsMap);
 
-  if (!isEqual(nextMap, currentMap)) {
+  if (!isEqual(nextMap, previousMap)) {
     return nextMap;
   }
   return null;
@@ -47,7 +47,7 @@ const getSequencesFromMap = (hotKeyName, hotKeyMap = {},) => {
   return [sequences];
 };
 
-const buildBindArray = (bindArray, kbjs, wrapper, handlers, keyMap) => {
+const buildBindArray = (bindArray, wrapper, handlers, keyMap) => {
   Object.keys(handlers).forEach(h => {
     let sequences = getSequencesFromMap(h, keyMap);
 
@@ -90,7 +90,7 @@ class HotKeys extends React.Component {
         hotKeyParent: {
           childHandledSequence
         },
-        hotKeyMap: buildMap(props.HKcontext.hotKeyMap, props.keyMap)
+        hotKeyMap: {}
       }
     };
 
@@ -104,6 +104,7 @@ class HotKeys extends React.Component {
     const nextMap = updateMap(
       props.HKcontext.hotKeyMap,
       props.keyMap,
+      {},
       state.HKcontext.hotKeyMap
     );
 
@@ -123,8 +124,8 @@ class HotKeys extends React.Component {
     this.updateHotKeys(true);
   }
 
-  componentDidUpdate(prevProps) {
-    this.updateHotKeys(false, prevProps);
+  componentDidUpdate(prevProps, prevState) {
+    this.updateHotKeys(false, prevProps, prevState);
     if (!isEqual(prevProps.keyMap, this.props.keyMap)) {
       this.setState({ timeStamp: new Date().getTime() });
     }
@@ -167,27 +168,28 @@ class HotKeys extends React.Component {
     }
   };
 
-  updateHotKeys = (force = false, prevProps = {}) => {
-    const { handlers = {}, keyMap } = this.props;
+  updateHotKeys = (force = false, prevProps = {}, prevState = {}) => {
+    const { handlers = {}, keyMap, HKcontext = {} } = this.props;
     const {
       HKcontext: { hotKeyMap: combinedKeyMap }
     } = this.state;
+
     const prevHandlers = prevProps.handlers || {};
 
     if (
       !force &&
-      !updateMap(combinedKeyMap, keyMap) &&
+      !updateMap(HKcontext.hotKeyMap, combinedKeyMap, keyMap, prevState?.HKcontext.hotKeyMap ) &&
       isEqual(handlers, prevHandlers)
     ) {
       return;
     }
 
-    this.keyboardjs.stop();
+    this.keyboardjs.stop(); // removes any keys from kbjs's queue, unbinds its listeners.
+    this.keyboardjs.reset(); // removes all listeners
     this.localKeybindings = [];
     // bind local keys first, preferring their keyMapped sequences over potential duplicates from context.
     buildBindArray(
       this.localKeybindings,
-      this.keyboardjs,
       this.handlerWrapper,
       handlers,
       keyMap
@@ -195,7 +197,6 @@ class HotKeys extends React.Component {
     // add keys from context into binding array...
     buildBindArray(
       this.localKeybindings,
-      this.keyboardjs,
       this.handlerWrapper,
       handlers,
       combinedKeyMap

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-react-hotkeys",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Stripes' hotkey library based on react-hotkeys.",
   "main": "index",
   "module": "index.es",

--- a/test/HotKeys/UpdateHandling.spec.js
+++ b/test/HotKeys/UpdateHandling.spec.js
@@ -1,0 +1,168 @@
+import React from 'react';
+import {expect} from 'chai';
+import sinon from 'sinon';
+import { fireEvent } from '@testing-library/react';
+
+import HotKeysHarness from '../support/Harness';
+import {mount, setup} from '../setup';
+import KeyCode from '../support/KeyCode';
+import FocusableElement from '../support/FocusableElement';
+
+let outer_outer_enter = sinon.spy(() => console.log('outer_outer_enter'));
+let outer_inner_enter = sinon.spy(() => console.log('outer_inner_enter'));
+let inner_outer_enter = sinon.spy(() => console.log('inner_outer_enter'));
+let inner_inner_enter = sinon.spy(() => console.log('inner_inner_enter'));
+let enterOuterHandler = sinon.spy(() => console.log('enterOuter'));
+let enterInnerHandler = sinon.spy(() => console.log('enterInner'));
+
+let tabOuterHandler = sinon.spy(() => console.log('tabOuter'));
+let tabInnerHandler = sinon.spy(() => console.log('tabInner'));
+let tabHandler = sinon.spy(() => console.log('tabHandler'));
+
+let altOuterHandler = sinon.spy(() => console.log('altOuter'));
+let altInnerHandler = sinon.spy(() => console.log('altInner'));
+let altHandler = sinon.spy(() => console.log('altHandler'));
+
+let downOuterHandler = sinon.spy(() => console.log('downOuter'));
+
+const resetHandlers = () => {
+  enterOuterHandler.resetHistory();
+  enterInnerHandler.resetHistory();
+
+  tabOuterHandler.resetHistory();
+  tabInnerHandler.resetHistory();
+  tabHandler.resetHistory();
+
+  altOuterHandler.resetHistory();
+  altInnerHandler.resetHistory();
+  altHandler.resetHistory();
+
+  outer_outer_enter.resetHistory();
+  outer_inner_enter.resetHistory();
+
+  inner_outer_enter.resetHistory();
+  inner_inner_enter.resetHistory();
+
+  downOuterHandler.resetHistory();
+}
+
+describe('Update Handling', () => {
+  setup();
+  beforeEach(function() {
+    this.altOuterKey = {
+      'TAB': 'down'
+    };
+
+    this.altOuterHandler = {
+      'TAB': downOuterHandler
+    };
+
+    this.outerKeyMap = {
+      'ENTER_OUTER': 'enter',
+      'TAB': 'tab',
+    };
+
+    this.innerKeyMap = {
+      'ENTER_INNER': 'enter',
+      'ALT': 'alt',
+    };
+
+    this.outerHandlers = {
+      'ENTER_OUTER': outer_outer_enter,
+      'TAB': tabOuterHandler,
+      'ENTER_INNER': outer_inner_enter,
+      'ALT': altOuterHandler,
+    };
+
+    this.innerHandlers = {
+      'ENTER_OUTER': inner_outer_enter,
+      'TAB': tabInnerHandler,
+      'ENTER_INNER': inner_inner_enter,
+      'ALT': altInnerHandler,
+    };
+
+    this.wrapper = mount(
+      <HotKeysHarness
+        innerKeyMap={this.innerKeyMap}
+        innerHandlers={this.innerHandlers}
+        outerKeyMap={this.outerKeyMap}
+        outerHandlers={this.outerHandlers}
+        innerTestId="innerTestId"
+        outerTestId="outerTestId"
+        changeKeyTestId="changeKey"
+        changeHandlerTestId="changeHandler"
+        alternativeOuterKey={this.altOuterKey}
+        alternativeOuterHandler={this.altOuterHandler}
+      />
+    );
+
+    this.outerInput = new FocusableElement(this.wrapper, 'outerTestId');
+    this.innerInput = new FocusableElement(this.wrapper, 'innerTestId');
+  });
+
+  describe('basic functionality', () => {
+    beforeEach( function () {
+      resetHandlers();
+    });
+
+    it('handles key press for outer HotKeys', function () {
+      this.outerInput.focus();
+      this.outerInput.keyDown(KeyCode.TAB);
+      expect(tabOuterHandler.calledOnce).to.be.true;
+    });
+
+    it('handles key press for inner HotKeys', function () {
+      this.innerInput.focus();
+      this.innerInput.keyDown(KeyCode.TAB);
+      expect(tabInnerHandler.calledOnce).to.be.true;
+    });
+
+    describe('after a state update', function() {
+      beforeEach(function() {
+        this.outerInput.fill('test');
+      });
+
+      it('displays changed value', function () {
+        expect(this.outerInput.getInstance().value).to.equal('test');
+      });
+
+      it('calls handlers only once for outer HotKeys', function () {
+        this.outerInput.focus();
+        this.outerInput.keyDown(KeyCode.TAB);
+        expect(tabOuterHandler.callCount).to.equal(1);
+      });
+
+      it('handles key press for inner HotKeys', function () {
+        this.innerInput.focus();
+        this.innerInput.keyDown(KeyCode.TAB);
+        expect(tabInnerHandler.callCount).to.equal(1);
+      });
+    });
+  });
+
+  describe('changing hotKey mapping', function() {
+    beforeEach(async function() {
+      this.changeButton = this.wrapper.getByTestId('changeKey');
+      await fireEvent.click(this.changeButton);
+    });
+
+    it('updates outer hotkey mapping', function() {
+      this.outerInput.focus();
+      this.outerInput.keyDown(KeyCode.DOWN);
+      expect(tabOuterHandler.callCount).to.equal(1);
+    });
+  });
+
+  describe('changing handler mapping', function() {
+    beforeEach(async function() {
+      this.changeButton = this.wrapper.getByTestId('changeHandler');
+      await fireEvent.click(this.changeButton);
+    });
+
+    it('updates outer handler mapping', function() {
+      this.outerInput.focus();
+      this.outerInput.keyDown(KeyCode.TAB);
+      expect(downOuterHandler.callCount).to.equal(1);
+    });
+  });
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,9 +1,8 @@
 import ReactDOM from 'react-dom';
 import chai from 'chai';
-import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import chaiDOM from 'chai-dom';
-import { render, cleanup } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 function cleanTestRoot() {
   let $root = document.getElementById('root');

--- a/test/support/FocusableElement.js
+++ b/test/support/FocusableElement.js
@@ -23,6 +23,10 @@ export default class FocusableElement {
     fireEvent.keyUp(this.element, { keyCode });
   }
 
+  fill(value) {
+    fireEvent.change(this.element, { target: { value: 'test' } });
+  }
+
   getInstance() {
     return this.element;
   }

--- a/test/support/Harness.js
+++ b/test/support/Harness.js
@@ -1,0 +1,50 @@
+/**
+ * HotKeyHarness - used for testing conditions for rendering within a stateful component.
+ */
+
+import React, { useState } from 'react';
+import { HotKeys } from '../../lib';
+
+const HotKeysHarness = ({ 
+  outerHandlers,
+  outerKeyMap,
+  innerHandlers,
+  innerKeyMap,
+  innerTestId,
+  outerTestId,
+  changeKeyTestId,
+  changeHandlerTestId,
+  alternativeOuterHandler,
+  alternativeOuterKey,
+}) => {
+  const [value, setValue] = useState('fill');
+  const [outerH, setOuterH] = useState(outerHandlers);
+  const [outerK, setOuterK] = useState(outerKeyMap);
+
+  const changeKey = () => {
+    setOuterK(current => {
+      return Object.assign({}, current, alternativeOuterKey);
+    });
+  }
+
+  const changeHandler = () => {
+    setOuterH(current => {
+      return Object.assign({}, current, alternativeOuterHandler);
+    });
+  }
+
+  return (
+    <div>
+      <button data-testid={changeKeyTestId} type="button" onClick={changeKey}>Change Key</button>
+      <button data-testid={changeHandlerTestId} type="button" onClick={changeHandler}>Change Handler</button>
+      <HotKeys keyMap={outerK} handlers={outerH} id="outer">
+        <input data-testid={outerTestId} value={value} onChange={(e) => { setValue(e.target.value); }} />
+        <HotKeys keyMap={innerKeyMap} handlers={innerHandlers} id="inner">
+          <input data-testid={innerTestId} />
+        </HotKeys>
+      </HotKeys>
+    </div>
+  );
+};
+
+export default HotKeysHarness;

--- a/test/support/KeyCode.js
+++ b/test/support/KeyCode.js
@@ -2,7 +2,8 @@ export default {
   ENTER: 13,
   TAB: 9,
   ALT: 18,
-
+  DOWN: 40,
+  UP: 38, 
   A: 65,
   B: 66,
 };


### PR DESCRIPTION
## Problem
After state updates/re-renders, handlers are called multiple times.

## Approach
Adjust the logic for checking whether or not updates/re-binds should happen. Reset keyboardjs with every re-binding of keys/handlers to remove ALL listeners.