### PR TITLE
Use named imports from keyboardjs

### DIFF
--- a/lib/HotKeys.js
+++ b/lib/HotKeys.js
@@ -8,8 +8,8 @@ import isBool from "lodash/isBoolean";
 import isArray from "lodash/isArray";
 import omit from "lodash/omit";
 import { withHotKeys, HotKeysProvider } from "./HotKeysContext";
-import Keyboard from "keyboardjs/lib/keyboard";
-import usLocale from "keyboardjs/locales/us";
+import { Keyboard } from "keyboardjs/lib/keyboard";
+import { us as usLocale } from "keyboardjs/locales/us";
 
 const buildMap = (currentMap = {}, contextMap = {}, propsMap = {}) =>
   Object.assign({}, currentMap, contextMap, propsMap);


### PR DESCRIPTION
## Purpose
`keyboardjs` has released a new minor version `2.6.0` a few hours ago, which contains a breaking change (using named export for `Keyboard` class and `us` locale instead of default exports in a previous version)