### PR TITLE
pin keyboardjs to 2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Stripes-react-hotkeys
 
+## [3.0.7] (IN PROGRESS)
+- pin `keyboardjs` to `2.5.1`
+
 ## [1.1.0](https://github.com/folio-org/stripes-react-hotkeys/tree/v1.1.0) (2018-09-12)
 [Full Changelog](https://github.com/folio-org/stripes-react-hotkeys/compare/v1.0.0...v1.1.0)
 

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   "browserslist": "> 0.25%",
   "dependencies": {
     "core-js": "^3.0.0",
-    "keyboardjs": "^2.5.1",
+    "keyboardjs": "~2.5.1",
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2"
   },


### PR DESCRIPTION
`keyboardjs` has released a new minor version `2.6.0` a few hours ago, which contains a breaking change (using named export for `Keyboard` class and `us` locale instead of default exports in a previous version)