### PR TITLE
STCOM-768 Autofocus fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Stripes-react-hotkeys
 
+## [3.0.8](https://github.com/folio-org/stripes-react-hotkeys/tree/v3.0.8) (2020-12-01)
+[Full Changelog](https://github.com/folio-org/stripes-react-hotkeys/compare/v3.0.7...v3.0.8)
+
+* check for contained document.activeElement on mount.
+
 ## [3.0.7](https://github.com/folio-org/stripes-react-hotkeys/tree/v3.0.7) (2020-06-05)
 [Full Changelog](https://github.com/folio-org/stripes-react-hotkeys/compare/v3.0.6...v3.0.7)
 

--- a/lib/HotKeys.js
+++ b/lib/HotKeys.js
@@ -122,6 +122,12 @@ class HotKeys extends React.Component {
     this.keyboardjs = new Keyboard(this.attachment);
     this.keyboardjs.setLocale("us", usLocale);
     this.updateHotKeys(true);
+
+    // if focus is already contained here, set isFocused to true...
+    // this can happen when autoFocus is used on child elements...
+    if (contains(this.attachment, document.activeElement)) {
+      this.isFocused = true;
+    }
   }
 
   componentDidUpdate(prevProps, prevState) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-react-hotkeys",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "Stripes' hotkey library based on react-hotkeys.",
   "main": "index",
   "module": "index.es",

--- a/test/HotKeys/HandlersAndDOMFocusing.spec.js
+++ b/test/HotKeys/HandlersAndDOMFocusing.spec.js
@@ -70,6 +70,31 @@ describe('Activating hotkeys by focusing in the DOM:', () => {
     });
   });
 
+  context('when a contained element is auto-focused', () => {
+    beforeEach(async function () {
+      this.handler = sinon.spy();
+
+      const handlers = {
+        'ENTER': this.handler,
+      };
+
+      this.wrapper = await mount(
+        <div >
+          <HotKeys keyMap={this.keyMap} handlers={handlers}>
+            <input autoFocus data-testid="childElement" />
+          </HotKeys>
+        </div>
+        );
+
+        this.input = new FocusableElement(this.wrapper, 'childElement');
+    });
+
+    it('then calls the correct handler when a key is pressed that matches the keyMap', function() {
+      this.input.keyDown(KeyCode.ENTER);
+      expect(this.handler.called).to.be.true;
+    });
+  });
+
   context('when a keyMap is provided to a parent component and a handler to a child component', () => {
 
     beforeEach(function () {


### PR DESCRIPTION
This addresses an issue when containing elements are auto-focused via an `autoFocus` prop. The elements seem to mount simultaneously so the usual onFocus handlers don't catch.

Addresses [STCOM-768](https://issues.folio.org/browse/STCOM-768)

## Approach

Simply check to see if document.activeElement is contained on mount.