### PR TITLE
STRIPES-772 contains returns false on falsey input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Stripes-react-hotkeys
 
+## IN PROGRESS
+
+* `contains` should by null-safe. Refs STRIPES-772.
+
 ## [3.0.8](https://github.com/folio-org/stripes-react-hotkeys/tree/v3.0.8) (2020-12-01)
 [Full Changelog](https://github.com/folio-org/stripes-react-hotkeys/compare/v3.0.7...v3.0.8)
 

--- a/lib/contains.js
+++ b/lib/contains.js
@@ -1,7 +1,13 @@
 export default function contains(container, node) {
-  /* istanbul ignore else */
-  if (container.contains) return container.contains(node)
-  /* istanbul ignore next */
-  if (container.compareDocumentPosition)
-    return container === node || (container.compareDocumentPosition(node) === 16)
+  if (container && node) {
+    /* istanbul ignore else */
+    if (container.contains) {
+      return container.contains(node);
+    }
+    /* istanbul ignore next */
+    if (container.compareDocumentPosition) {
+      return container === node || (container.compareDocumentPosition(node) === 16);
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
Instead of throwing an NPE, `contains` now returns `false` if either
argument is falsey.

Refs [STRIPES-772](https://issues.folio.org/browse/STRIPES-772)