### PR TITLE
[STRIPES-900] Remove explicit typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "rollup-plugin-uglify": "^6.0.4",
     "sinon": "^4.0.0",
     "sinon-chai": "^2.14.0",
-    "typescript": "^3.7.5",
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.10",
     "webpack-dev-server": "^3.10.3"


### PR DESCRIPTION
As part of [Jira STRIPES-900](https://issues.folio.org/browse/STRIPES-900), all modules should use one `typescript` version, inherited from `@folio/stripes-webpack`.  Therefore, the explicit `typescript` version in this `package.json` should be removed.
