### PR TITLE
use current shared workflows

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -6,10 +6,9 @@ on:
 
 jobs:
   ui:
-    # Use the shared workflow from https://github.com/folio-org/.github
     uses: folio-org/.github/.github/workflows/ui.yml@v1
-    # Only handle push events from the main branch, to decrease noise
-    if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push'
+    # on the main branch, only run on push and tag events, to prevent duplicate runs
+    if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push' || github.ref_type == 'tag'
     secrets: inherit
     with:
       jest-enabled: false


### PR DESCRIPTION
Avoid running actions twice on push (a PR triggers 2 events but we only need to run the actions once).